### PR TITLE
docs: 修复失效的 Star History 图表

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -100,11 +100,11 @@
 ## ⭐ Star History
 
 <p align="center">
-  <a href="https://www.star-history.com/#tomakino/lyricon&Date">
+  <a href="https://star-history.dera.page/#tomakino/lyricon&type=Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tomakino/lyricon&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tomakino/lyricon&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=tomakino/lyricon&type=Date" width="600" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=tomakino/lyricon&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=tomakino/lyricon&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=tomakino/lyricon&type=Date" width="600" />
     </picture>
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@
 ## ⭐ Star History
 
 <p align="center">
-  <a href="https://www.star-history.com/#tomakino/lyricon&Date">
+  <a href="https://star-history.dera.page/#tomakino/lyricon&type=Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tomakino/lyricon&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tomakino/lyricon&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=tomakino/lyricon&type=Date" width="600" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=tomakino/lyricon&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=tomakino/lyricon&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=tomakino/lyricon&type=Date" width="600" />
     </picture>
   </a>
 </p>


### PR DESCRIPTION
Star History 图表目前因 GitHub API 限制已无法正常显示，此改动将其切换到新数据源，可恢复图表展示且无需 API token。